### PR TITLE
Facilities and organizations: use @entityID instead of text().

### DIFF
--- a/repo/csd_base_library.xqm
+++ b/repo/csd_base_library.xqm
@@ -448,11 +448,11 @@ declare function csd:filter_by_parent($items as item()*,$parent as item()*) as i
 declare function csd:filter_by_organizations($items as item()*,$orgs as item()*) as item()*
 {
     if (count($orgs) = 0 
-       or not ($orgs[1]/text())
+       or not ($orgs[1]/@entityID)
     ) 
     then  $items
     else  
-           let $org := upper-case($orgs[1]/text())
+           let $org := upper-case($orgs[1]/@entityID)
            return csd:filter_by_organizations(
 	     $items[organizations/organization[upper-case(@entityID) = $org]],
 	     fn:subsequence($orgs,2))
@@ -472,11 +472,11 @@ declare function csd:filter_by_organizations($items as item()*,$orgs as item()*)
 declare function csd:filter_by_facilities($items as item()*,$facs as item()*) as item()*
 {
     if (count($facs) = 0 
-       or not ($facs[1]/text())
+       or not ($facs[1]/@entityID)
     ) 
     then  $items
     else  
-           let $fac := upper-case($facs[1]/text())
+           let $fac := upper-case($facs[1]/@entityID)
            return csd:filter_by_facilities(
 	     $items[facilities/facility[upper-case(@entityID) = $fac]],
 	     fn:subsequence($facs,2))

--- a/repo/csd_base_stored_queries.xqm
+++ b/repo/csd_base_stored_queries.xqm
@@ -40,14 +40,22 @@ declare function csd_bsq:provider_search($requestParams, $doc) as element()
 	then csd_bl:filter_by_record($provs4,$requestParams/record)      
       else  $provs4
 
+      let $provs6 :=  if (exists($requestParams/facilities/facility)) 
+	then csd_bl:filter_by_facilities($provs5,$requestParams/facilities/facility)      
+      else  $provs5
+
+      let $provs7 :=  if (exists($requestParams/organizations/organization)) 
+	then csd_bl:filter_by_organizations($provs6,$requestParams/organizations/organization)      
+      else  $provs6
+
       return if (exists($requestParams/start)) then
 	if (exists($requestParams/max)) 
-	  then csd_bl:limit_items($provs5,$requestParams/start,$requestParams/max)         
-	else csd_bl:limit_items($provs5,$requestParams/start,<max/>)         
+	  then csd_bl:limit_items($provs7,$requestParams/start,$requestParams/max)         
+	else csd_bl:limit_items($provs7,$requestParams/start,<max/>)         
       else
 	if (exists($requestParams/max)) 
-	  then csd_bl:limit_items($provs5,<start/>,$requestParams/max)         
-	else $provs5
+	  then csd_bl:limit_items($provs7,<start/>,$requestParams/max)         
+	else $provs7
 )
 
 };

--- a/resources/stored_query_definitions/provider_search.xq
+++ b/resources/stored_query_definitions/provider_search.xq
@@ -55,7 +55,7 @@ declare variable $careServicesRequest as item() external;
       else
 	if (exists($careServicesRequest/max)) 
 	  then csd_bl:limit_items($provs7,<start/>,$careServicesRequest/max)         
-	else $provs5
+	else $provs7
 
     }     
   </providerDirectory>


### PR DESCRIPTION
provider_search: return facs7
Added fac and org filtering for providers to base stored queries
