### PR TITLE
Fixes for the updating query definitions

### DIFF
--- a/resources/stored_updating_query_definitions/facility_create.xq
+++ b/resources/stored_updating_query_definitions/facility_create.xq
@@ -13,8 +13,8 @@ declare variable $careServicesRequest as item() external;
    and limit paramaters as sent by the Service Finder
 :) 
 for $fac in $careServicesRequest/facility
-  let $existing := if (exists($fac/@entityID)) then csd_bl:filter_by_primary_id(/CSD/facilityDirectory/*,$fac/@entityID) else ()  
+  let $existing := if (exists($fac/@entityID)) then csd_bl:filter_by_primary_id(/CSD/facilityDirectory/*,$fac) else ()
   return
     if (exists($existing)) 
-    then insert node $fac into /CSD/facilityDirectory
-    else replace node $existing with $fac
+    then replace node $existing with $fac
+    else insert node $fac into /CSD/facilityDirectory

--- a/resources/stored_updating_query_definitions/organization_create.xq
+++ b/resources/stored_updating_query_definitions/organization_create.xq
@@ -13,8 +13,8 @@ declare variable $careServicesRequest as item() external;
    and limit paramaters as sent by the Service Finder
 :) 
 for $org in $careServicesRequest/organization
-  let $existing := if (exists($org/@entityID)) then csd_bl:filter_by_primary_id(/CSD/organizationDirectory/*,$org/@entityID) else ()  
+  let $existing := if (exists($org/@entityID)) then csd_bl:filter_by_primary_id(/CSD/organizationDirectory/*,$org) else ()
   return
     if (exists($existing)) 
-    then insert node $org into /CSD/organizationDirectory
-    else replace node $existing with $org
+    then replace node $existing with $org
+    else insert node $org into /CSD/organizationDirectory

--- a/resources/stored_updating_query_definitions/provider_create.xq
+++ b/resources/stored_updating_query_definitions/provider_create.xq
@@ -13,8 +13,8 @@ declare variable $careServicesRequest as item() external;
    and limit paramaters as sent by the Service Finder
 :) 
 for $prov in $careServicesRequest/provider
-  let $existing := if (exists($prov/@entityID)) then csd_bl:filter_by_primary_id(/CSD/providerDirectory/*,$prov/@entityID) else ()  
+  let $existing := if (exists($prov/@entityID)) then csd_bl:filter_by_primary_id(/CSD/providerDirectory/*,$prov) else ()
   return
     if (exists($existing)) 
-    then insert node $prov into /CSD/providerDirectory
-    else replace node $existing with $prov
+    then replace node $existing with $prov
+    else insert node $prov into /CSD/providerDirectory

--- a/resources/stored_updating_query_definitions/service_create.xq
+++ b/resources/stored_updating_query_definitions/service_create.xq
@@ -13,8 +13,8 @@ declare variable $careServicesRequest as item() external;
    and limit paramaters as sent by the Service Finder
 :) 
 for $srvc in $careServicesRequest/service
-  let $existing := if (exists($srvc/@entityID)) then csd_bl:filter_by_primary_id(/CSD/serviceDirectory/*,$srvc/@entityID) else ()  
+  let $existing := if (exists($srvc/@entityID)) then csd_bl:filter_by_primary_id(/CSD/serviceDirectory/*,$srvc) else ()
   return
     if (exists($existing)) 
-    then insert node $srvc into /CSD/serviceDirectory
-    else replace node $existing with $srvc
+    then replace node $existing with $srvc
+    else insert node $srvc into /CSD/serviceDirectory


### PR DESCRIPTION
Hi @litlfred 

I ran into issues when trying to run facility create/update transactions but think I managed to trace the problem. Please let me know if these changes make sense.

For reference the transaction I tested with is (and works with these changes):
```
curl -i -X POST -H 'content-type: text/xml' --data-binary @request.xml http://localhost:8984/CSD/csr/CSD-Facilities-Connectathon-20150120/careServicesRequest/update/urn:openhie.org:openinfoman:facility_create
```
```
<requestParams xmlns="urn:ihe:iti:csd:2013">
  <facility entityID="urn:uuid:be4d27c3-21b8-481f-9fed-6524a8eb9bac">
    <otherID code="jembi104" codingSchema="testing"/>
    <address type="Practice">
      <addressLine component="streetAddress">Unit D11 Westlake Square</addressLine>
      <addressLine component="city">Cape Town</addressLine>
      <addressLine component="country">South Africa</addressLine>
    </address>
  </facility>
</requestParams>
```