### PR TITLE
Update install.sh

### DIFF
--- a/resources/scripts/install.sh
+++ b/resources/scripts/install.sh
@@ -56,7 +56,7 @@ cp -R $HOME/openinfomangh/webapp/static/* $HOME/openinfoman/webapp/static
 
 printf "module namespace csd_webconf = 'https://github.com/openhie/openinfoman/csd_webconf';
 declare variable \$csd_webconf:db :=  'provider_directory';
-declare variable \$csd_webconf:baseurl :=  '';
+declare variable \$csd_webconf:baseurl :=  'https://$( hostname ):5000/node/ilr';
 declare variable \$csd_webconf:remote_services := ();
 " > $HOME/openinfoman/repo-src/generated_openinfoman_webconfig.xqm
 


### PR DESCRIPTION
Added https://$( hostname ):5000/node/ilr to declaration of `$csd_webconf:baseurl` created as `$HOME/openinfoman/repo-src/generated_openinfoman_webconfig.xqm` to support css showing after install.

This is due to the css not loading after Infoman install on DATIM4U.